### PR TITLE
add condition for different blog articles single template

### DIFF
--- a/templates/article.liquid
+++ b/templates/article.liquid
@@ -1,3 +1,18 @@
 <h2>{{ article.title }}</h2>
 <p>{{ article.published_at | date: '%d %B %Y' }}</p>
-{{ article.content }}
+{% if blog.handle == 'lookbook' %}
+
+  {% if article.content contains "<img" %}
+    {% assign gallery-src = article.content | split: 'src="' %}
+    {% assign gallery-size = gallery-src.size | minus:1 %}
+    {% for i in (1..gallery-size) %}
+      <h3>This is a lookbook</h3>
+      <li class="lookbook-image">
+        <img src="{{gallery-src[i]}}" />
+      </li>
+    {% endfor %}
+  {% endif %}
+
+{% else %}
+  {{ article.content }}
+{% endif %}


### PR DESCRIPTION
This adds the condition that check if an aritcle is part of _blog_ or _lookbook_ and returns different markup.
Also checks for all images in the article `content` and loops thru them. Needed to style the lookbook gallery. The randomized padding will have to be done with javascript because liquid doesn't do random numbers.

This is the original wordpress code for reference:https://github.com/interglobalvision/apt25-com-mx/blob/966bfe6a95af4a6d9d46db6f4acc33a2611f5daf/lib/gallery.php